### PR TITLE
Add support for using current date when logging entry w/ no date

### DIFF
--- a/code/CmdLineParser.h
+++ b/code/CmdLineParser.h
@@ -9,6 +9,8 @@
 #include <sys/types.h> 
 #include <sys/stat.h>
 
+#include <time.h>
+
 class CParser
 {
 
@@ -459,7 +461,7 @@ bool CParser::CheckUserEnteredProperDate(bool bPrintSpecificTable)
       }
    }
 
-   if (!bDateAvailable)
+   if (!bDateAvailable && bLog)
    {
       /*
        * Return true here if no date option was entered on the commandline,

--- a/code/CmdLineParser.h
+++ b/code/CmdLineParser.h
@@ -256,6 +256,8 @@ bool CParser::DataFieldExists(std::string sCmd)
 std::string CParser::GetDate()
 {
    vectorOfStringIT it = m_vecDataFields.begin();
+   time_t time_raw;
+   char buf[12];
 
    size_t iIndex;
    for (; it != m_vecDataFields.end(); it++)
@@ -267,7 +269,9 @@ std::string CParser::GetDate()
          return (*it).substr(iIndex + 1);
       }
    }
-   return "";
+   time(&time_raw);
+   strftime(buf, 12, "%d/%m/%Y", localtime(&time_raw));
+   return buf;
 }
 
 // Extracts the value associated with a data field
@@ -457,7 +461,11 @@ bool CParser::CheckUserEnteredProperDate(bool bPrintSpecificTable)
 
    if (!bDateAvailable)
    {
-      return false;
+      /*
+       * Return true here if no date option was entered on the commandline,
+       * since we will use today's date later on
+       */
+      return true;
    }
 
    if (bPrintSpecificTable)

--- a/code/main.cpp
+++ b/code/main.cpp
@@ -863,6 +863,7 @@ void PrintHelp()
    std::cout << "      -------------------------------- *** To log expenses ***\n\n";
    std::cout << "      log -d=<date> -<code>=<quantity>   + The date must be specified in the format 'day/month/year' (e.g. 19/7/2016).\n";
    std::cout << "                                         + The date must be valid (e.g. February 29 is only valid on leap years).\n";
+   std::cout << "                                         + If no date is provided, today's date will be used.\n";
    std::cout << "                                         + Quantities must be real numbers.\n";
    std::cout << "                                         + Numbers that contain more than 12 digits are rounded.\n\n\n";
 

--- a/code/main.cpp
+++ b/code/main.cpp
@@ -54,7 +54,7 @@ std::string strPrintOutPath = "pfox_console_printout.js";
 std::string strDatabasePath = "pfox_expenses.db";
 std::string strTableCategoriesPath = "pfox_categories.txt";
 
-const std::string sVersion = "1.0.0";
+const std::string sVersion = "1.1.0";
 
 int main(int argc, char * argv[])
 {


### PR DESCRIPTION
This adds support for automatically using today's date if the user does
not enter a date when using the 'log' function. I'm not totally happy
with the way I modified the "CheckUserEnteredProperDate" to essentially
ignore the fact the user didn't specify -d at the commandline, which was
necessary to have the program continue so that today's date could be
used later on. Definitely open to suggestions if there's a better way to
do that!